### PR TITLE
Add example concept JSON objects

### DIFF
--- a/samples/are_you_eligible.json
+++ b/samples/are_you_eligible.json
@@ -1,0 +1,70 @@
+{
+  "title": "Are you eligible",
+  "@type": "dcat:DataService",
+  "alternativeTitle": [
+    "Servide informing you as to whether you are eligible"
+  ],
+  "summary": "A service that responds to an input with a Yes or No response",
+  "description": "A Restful API that returns yes or no answer depending on the data input",
+  "keyword": [
+    "Eligibility"
+  ],
+  "theme": [
+    "Business, economics, and finance"
+  ],
+  "contactPoint": {
+    "contactName": "Rob Nichols",
+    "email": "robert.nichols@digital.cabinet-office.gov.uk"
+  },
+  "creator": [
+    "department-for-business-and-trade"
+  ],
+  "publisher": "department-for-business-and-trade",
+  "securityClassification": "OFFICIAL",
+  "identifier": "8d085327-21b6-4d8b-9705-88faad231d22",
+  "relatedResource": [
+    ""
+  ],
+  "serviceType": "REST",
+  "serivceStatus": "BETA",
+  "endpointURL": "http://example.com/service/api",
+  "endpointDescription": "A service API",
+  "servesDataset": [
+    {
+      "title": "Yes or No",
+      "@type": "dcat:Dataset",
+      "alternativeTitle": [],
+      "summary": "An object that will return either 'yes' or 'no'",
+      "description": "An object with a single property 'result' that will be either 'yes' or 'no'",
+      "keyword": [
+        "Boolean"
+      ],
+      "theme": [],
+      "contactPoint": {
+        "contactName": "Rob Nichols",
+        "email": "robert.nichols@digital.cabinet-office.gov.uk"
+      },
+      "creator": [
+        "department-for-business-and-trade"
+      ],
+      "publisher": "department-for-education",
+      "securityClassification": "OFFICIAL",
+      "identifier": "8d085327-21b6-4d8b-9705-88faad231d21",
+      "relatedResource": [
+        ""
+      ],
+      "distribution": {
+        "title": "JSON Object",
+        "@type": "dcat:Distribution",
+        "accessService": "8d085327-21b6-4d8b-9705-88faad231d63",
+        "identifier": "response",
+        "modified": "2024-05-02",
+        "issued": "2024-05-02",
+        "licence": "",
+        "byteSize": 20,
+        "mediaType": "application/json"
+      }
+    }
+  ]
+}
+

--- a/samples/exam_results.json
+++ b/samples/exam_results.json
@@ -1,0 +1,110 @@
+{
+  "title": "Exam results service",
+  "@type": "dcat:DataService",
+  "alternativeTitle": [
+    "Servide providing annual exam results"
+  ],
+  "summary": "An API through which exam results can be retrieved for the past two years",
+  "description": "A Restful API that returns a number of dataset each representing the exam results for a particular year",
+  "keyword": [
+    "Exam Results"
+  ],
+  "theme": [
+    "Education"
+  ],
+  "contactPoint": {
+    "contactName": "Rob Nichols",
+    "email": "robert.nichols@digital.cabinet-office.gov.uk"
+  },
+  "creator": [
+    "department-for-education"
+  ],
+  "publisher": "department-for-education",
+  "securityClassification": "OFFICIAL",
+  "identifier": "8d085327-21b6-4d8b-9705-88faad231d63",
+  "relatedResource": [
+    ""
+  ],
+  "serviceType": "REST",
+  "serivceStatus": "BETA",
+  "endpointURL": "http://example.com/service/api",
+  "endpointDescription": "A service API",
+  "servesDataset": [
+    {
+      "title": "Exam results 2022",
+      "@type": "dcat:Dataset",
+      "alternativeTitle": [],
+      "summary": "Exam results for 2022",
+      "description": "A breakdown of example results by grade for the year 2022",
+      "keyword": [
+        "Exam Results",
+        "2022"
+      ],
+      "theme": [
+        "Education"
+      ],
+      "contactPoint": {
+        "contactName": "Rob Nichols",
+        "email": "robert.nichols@digital.cabinet-office.gov.uk"
+      },
+      "creator": [
+        "department-for-education"
+      ],
+      "publisher": "department-for-education",
+      "securityClassification": "OFFICIAL",
+      "identifier": "8d085327-21b6-4d8b-9705-88faad231d62",
+      "relatedResource": [
+        ""
+      ],
+      "distribution": {
+        "title": "JSON Object",
+        "@type": "dcat:Distribution",
+        "accessService": "8d085327-21b6-4d8b-9705-88faad231d63",
+        "identifier": "year/2022",
+        "modified": "2024-05-02",
+        "issued": "2024-05-02",
+        "licence": "",
+        "byteSize": 2045,
+        "mediaType": "application/json"
+      }
+    },
+    {
+      "title": "Exam results 2023",
+      "@type": "dcat:Dataset",
+      "alternativeTitle": [],
+      "summary": "Exam results for 2023",
+      "description": "A breakdown of example results by grade for the year 2023",
+      "keyword": [
+        "Exam Results",
+        "2023"
+      ],
+      "theme": [
+        "Education"
+      ],
+      "contactPoint": {
+        "contactName": "Rob Nichols",
+        "email": "robert.nichols@digital.cabinet-office.gov.uk"
+      },
+      "creator": [
+        "department-for-education"
+      ],
+      "publisher": "department-for-education",
+      "securityClassification": "OFFICIAL",
+      "identifier": "8d085327-21b6-4d8b-9705-88faad231d61",
+      "relatedResource": [
+        ""
+      ],
+      "distribution": {
+        "title": "JSON Object",
+        "@type": "dcat:Distribution",
+        "accessService": "8d085327-21b6-4d8b-9705-88faad231d63",
+        "identifier": "year/2023",
+        "modified": "2024-05-02",
+        "issued": "2024-05-02",
+        "licence": "",
+        "byteSize": 2045,
+        "mediaType": "application/json"
+      }
+    }
+  ]
+}

--- a/samples/spreadsheet.json
+++ b/samples/spreadsheet.json
@@ -1,0 +1,44 @@
+{
+  "title": "Overall Beta ESDA Initial Returns",
+  "@type": "dcat:Dataset",
+  "alternativeTitle": [],
+  "summary": "Log and analysis of ESDA spreadsheets returned to the Data Marketplace",
+  "description": "A spreadsheet compiled by the Data Marketplace team to keep track of the ESDAs returned by partnering department. The spreadsheet contains: A summary sheet showing a breakdown of ESDA returns by department; a sheet for each department with summary information about the individual ESDAs that have been submitted",
+  "keyword": [
+    "Data Marketplace",
+    "ESDA"
+  ],
+  "theme": [],
+  "contactPoint": {
+    "contactName": "Rob Nichols",
+    "email": "robert.nichols@digital.cabinet-office.gov.uk"
+  },
+  "creator": [
+    "central-digital-and-data-office"
+  ],
+  "publisher": "central-digital-and-data-office",
+  "securityClassification": "OFFICIAL",
+  "identifier": "",
+  "relatedResource": [
+    ""
+  ],
+  "version": "",
+  "issued": "2024-05-02",
+  "modified": "2024-05-02",
+  "created": "2024-02-13",
+  "updateFrequency": "freq:irregular",
+  "licence": "",
+  "accessRights": "INTERNAL",
+  "distribution": {
+    "title": "Google Sheet",
+    "@type": "dcat:Distribution",
+    "accessService": "path/to/sheet/in/google/sheets",
+    "identifier": "",
+    "modified": "2024-05-02",
+    "issued": "2024-05-02",
+    "licence": "",
+    "byteSize": 2045,
+    "mediaType": "application/vnd.google-apps.spreadsheet"
+  }
+
+}


### PR DESCRIPTION
The new example more closely represent real world cases. The highlight how submissions may need to combine (by nesting) objects of different types. So for example, a DataService may nest withing it, the DataSets it serves.