### PR TITLE
Add an Error schema

### DIFF
--- a/samples/error.json
+++ b/samples/error.json
@@ -1,0 +1,18 @@
+{
+  "message": "Validation failure",
+  "code": "401",
+  "errors": [
+    {
+      "type": "http://example.com/docs/errors/exceeded-max-length",
+      "detail": "The attribute 'summary' is too long. It should be less than 250 characters",
+      "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
+      "location": "/summary"
+    },
+    {
+      "type": "http://example.com/docs/errors/type-integer",
+      "detail": "The distribution byteSize of '1Mb' is not an integer",
+      "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
+      "location": "/distribution/byteSize"
+    }
+  ]
+}

--- a/samples/error.json
+++ b/samples/error.json
@@ -6,13 +6,15 @@
       "type": "http://example.com/docs/errors/exceeded-max-length",
       "detail": "The attribute 'summary' is too long. It should be less than 250 characters",
       "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
-      "location": "/summary"
+      "location": "/summary",
+      "severity": "minor"
     },
     {
       "type": "http://example.com/docs/errors/type-integer",
       "detail": "The distribution byteSize of '1Mb' is not an integer",
       "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
-      "location": "/distribution/byteSize"
+      "location": "/distribution/byteSize",
+      "severity": "major"
     }
   ]
 }

--- a/samples/nested_errors.json
+++ b/samples/nested_errors.json
@@ -1,0 +1,21 @@
+{
+  "message": "Validation failure",
+  "code": "401",
+  "errors": [
+    {
+      "type": "http://example.com/docs/errors/validation",
+      "detail": "The item 'Acme Object' has failed validation",
+      "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
+      "location": "/instances/[2]",
+      "errors": [
+        {
+          "type": "http://example.com/docs/errors/type-integer",
+          "detail": "The distribution byteSize of '1Mb' is not an integer",
+          "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
+          "location": "/instances/[2]/distribution/byteSize",
+          "severity": "3"
+        }
+      ]
+    }
+  ]
+}

--- a/schema/data_marketplace_dataset_schema.json
+++ b/schema/data_marketplace_dataset_schema.json
@@ -21,8 +21,8 @@
       "description": "An alternative name used as a substitute or additional access point for an information resource.",
       "type": "array",
       "items": {
-       "type": "string",
-      "maxLength": 200
+        "type": "string",
+        "maxLength": 200
       }
     },
     "contactPoint": {

--- a/schema/data_marketplace_error_schema.json
+++ b/schema/data_marketplace_error_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Data Marketplace Metadata - Dataset",
-  "$id": "Schemas/Dataset",
+  "title": "Data Marketplace Metadata - Error",
+  "$id": "Schemas/Error",
   "description": "Data Marketplace schema for an error object",
   "type": "object",
   "properties": {
@@ -14,34 +14,7 @@
       "description": "An array of the specific error details",
       "type": "array",
       "items": {
-        "description": "Error details object",
-        "type": "object",
-        "properties": {
-          "detail": {
-            "description": "Human readable description of the details of the error",
-            "type": "string",
-            "maxLength": 200
-          },
-          "instance": {
-            "description": "An identifier of the instance of the object where the error occured",
-            "type": "string",
-            "maxLength": 100
-          },
-          "location": {
-            "description": "A pointer to the location of the error within the instance.",
-            "type": "string",
-            "maxLength": 100
-          },
-          "type": {
-            "description": "A systematic identifier for the type of error.",
-            "type": "string",
-            "maxLength": 100
-          }
-        },
-        "requires": [
-          "detail",
-          "type"
-        ]
+        "$ref": "#/schemas/innerError"
       }
     },
     "message": {
@@ -55,5 +28,50 @@
     "code",
     "errors"
   ],
+  "schemas": {
+    "innerError": {
+      "$id": "schema/innerError",
+      "description": "Error details object",
+      "type": "object",
+      "properties": {
+        "detail": {
+          "description": "Human readable description of the details of the error",
+          "type": "string",
+          "maxLength": 200
+        },
+        "errors": {
+          "description": "An array of inner errors",
+          "type": "array",
+          "items": {
+            "$ref": "#/schemas/innerError"
+          }
+        },
+        "instance": {
+          "description": "An identifier of the instance of the object where the error occured",
+          "type": "string",
+          "maxLength": 100
+        },
+        "location": {
+          "description": "A pointer to the location of the error within the instance.",
+          "type": "string",
+          "maxLength": 100
+        },
+        "severity": {
+          "description": "Severity of error. Could be a level or description.",
+          "type": "string",
+          "maxLength": 100
+        },
+        "type": {
+          "description": "A systematic identifier for the type of error.",
+          "type": "string",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "detail",
+        "type"
+      ]
+    }
+  },
   "additionalProperties": false
 }

--- a/schema/data_marketplace_error_schema.json
+++ b/schema/data_marketplace_error_schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Data Marketplace Metadata - Dataset",
+  "$id": "Schemas/Dataset",
+  "description": "Data Marketplace schema for an error object",
+  "type": "object",
+  "properties": {
+    "code": {
+      "description": "A system specific code for the global error raised",
+      "type": "string",
+      "maxLength": 100
+    },
+    "errors": {
+      "description": "An array of the specific error details",
+      "type": "array",
+      "items": {
+        "description": "Error details object",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "description": "Human readable description of the details of the error",
+            "type": "string",
+            "maxLength": 200
+          },
+          "instance": {
+            "description": "An identifier of the instance of the object where the error occured",
+            "type": "string",
+            "maxLength": 100
+          },
+          "location": {
+            "description": "A pointer to the location of the error within the instance.",
+            "type": "string",
+            "maxLength": 100
+          },
+          "type": {
+            "description": "A systematic identifier for the type of error.",
+            "type": "string",
+            "maxLength": 100
+          }
+        },
+        "requires": [
+          "detail",
+          "type"
+        ]
+      }
+    },
+    "message": {
+      "description": "Summary description of the nature of the error",
+      "type": "string",
+      "maxLength": 100
+    }
+  },
+  "required": [
+    "message",
+    "code",
+    "errors"
+  ],
+  "additionalProperties": false
+}

--- a/schema_test.rb
+++ b/schema_test.rb
@@ -66,3 +66,8 @@ validate(
   sample: 'samples/error.json',
   schema: 'schema/data_marketplace_error_schema.json'
 )
+
+validate(
+  sample: 'samples/nested_errors.json',
+  schema: 'schema/data_marketplace_error_schema.json'
+)

--- a/schema_test.rb
+++ b/schema_test.rb
@@ -61,3 +61,8 @@ validate(
   sample: 'samples/group_of_dataset_references.json',
   schema: 'schema/data_marketplace_dataset_group_schema.json'
 )
+
+validate(
+  sample: 'samples/error.json',
+  schema: 'schema/data_marketplace_error_schema.json'
+)


### PR DESCRIPTION
The schema defines an error object that contains both information about the overall nature of the error, and an array of details of the specific errors.

The design resulted from a review of the following error object descriptions:

- https://cloud.google.com/storage/docs/json_api/v1/status-codes#401-unauthorized
- https://jsonapi.org/format/#error-objects
- https://www.mscharhag.com/api-design/rest-error-format

A typical error could look like this:

```json
{
  "message": "Validation failure",
  "code": "401",
  "errors": [
    {
      "type": "http://example.com/docs/errors/exceeded-max-length",
      "detail": "The attribute 'summary' is too long. It should be less than 250 characters",
      "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
      "location": "/summary"
    },
    {
      "type": "http://example.com/docs/errors/type-integer",
      "detail": "The distribution byteSize of '1Mb' is not an integer",
      "instance": "identifier:f58ce342-d3cc-4a13-bba4-ac958c39397b",
      "location": "/distribution/byteSize"
    }
  ]
}
```