### PR TITLE
Increase maximum distribution byte size

### DIFF
--- a/schema/data_marketplace_resource_group_schema.json
+++ b/schema/data_marketplace_resource_group_schema.json
@@ -213,7 +213,8 @@
         },
         "byteSize": {
           "description": "The size of the distribution in bytes.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         },
         "identifier": {
           "description": "A unique number, code, or reference value assigned to an information resource within a given context.",


### PR DESCRIPTION
Specify integer format for distribution byte size so that it is not limited to 2.1 GB