### PR TITLE
Make enum all of type "string"

### DIFF
--- a/schema/data_marketplace_data_service_schema.json
+++ b/schema/data_marketplace_data_service_schema.json
@@ -7,6 +7,7 @@
   "properties": {
     "@type": {
       "description": "Should be a DCAT object type",
+      "type": "string",
       "enum": ["dcat:DataService"]
     },
     "alternativeTitle": {
@@ -81,6 +82,7 @@
     },
     "securityClassification": {
       "description": "An information security designation that identifies the minimum level of protection assigned to an information resource.",
+      "type": "string",
       "enum": [
         "OFFICIAL",
         "SECRET",
@@ -104,6 +106,7 @@
     },
     "serviceStatus": {
       "description": "The status of the resource in the context of a particular workflow process.",
+      "type": "string",
       "enum": [
         "DISCOVERY",
         "ALPHA",
@@ -117,6 +120,7 @@
     },
     "serviceType": {
       "description": "Type of the service",
+      "type": "string",
       "enum": [
         "EVENT",
         "REST",
@@ -137,6 +141,7 @@
       "description": "Topic: A controlled term that expresses the broad topical content of an information resource. Subject: A controlled term that expresses a topic of the intellectual content of an information resource.",
       "type": "array",
       "items": {
+        "type": "string",
         "enum": [
           "Agriculture, fisheries and forestry",
           "Business, economics and finance",

--- a/schema/data_marketplace_dataset_schema.json
+++ b/schema/data_marketplace_dataset_schema.json
@@ -7,10 +7,12 @@
   "properties": {
     "@type": {
       "description": "Should be a DCAT object type",
+      "type": "string",
       "enum": ["dcat:Dataset"]
     },
     "accessRights": {
       "description": "A rights statement that concerns how the distribution is accessed.",
+      "type": "string",
       "enum": [
         "INTERNAL",
         "OPEN",
@@ -107,6 +109,7 @@
     },
     "securityClassification": {
       "description": "An information security designation that identifies the minimum level of protection assigned to an information resource.",
+      "type": "string",
       "enum": [
         "OFFICIAL",
         "SECRET",
@@ -128,6 +131,7 @@
       "description": "Topic: A controlled term that expresses the broad topical content of an information resource. Subject: A controlled term that expresses a topic of the intellectual content of an information resource.",
       "type": "array",
       "items": {
+        "type": "string",
         "enum": [
           "Agriculture, fisheries and forestry",
           "Business, economics and finance",
@@ -152,6 +156,7 @@
     },
     "updateFrequency": {
       "description": "",
+      "type": "string",
       "enum": [
         "freq:triennial",
         "freq:biennial",


### PR DESCRIPTION
Update to fix the following issue: could you please add "type": "string" for ALL enums - if they are not string the Swagger documentation doesn't know how to display them.