### PR TITLE
Reinstate error schema test

### DIFF
--- a/schema_test.rb
+++ b/schema_test.rb
@@ -47,3 +47,7 @@ validate(
   schema: 'schema/data_share_schema.json'
 )
 
+validate(
+  sample: 'samples/error.json',
+  schema: 'schema/error_schema.json'
+)


### PR DESCRIPTION
The error object is being retained from the previous schema models. However, the test of the error schema was left off the previous change and needs to be reinstated.