### PR TITLE
Make type an array to facilitate a record being both a dataset and a data service

### DIFF
--- a/samples/data_group.json
+++ b/samples/data_group.json
@@ -5,7 +5,7 @@
   "status": "Published",
   "title": "Annual exam results",
   "description": "A group of datasets, where each set represents the examination results for a particular year",
-  "type": "Data Group",
+  "type": ["Data Group"],
   "theme": [
     "Education"
   ],

--- a/samples/data_service.json
+++ b/samples/data_service.json
@@ -5,7 +5,7 @@
   "status": "Published",
   "title": "Advance Passenger Information",
   "description": "Travel data and personal data given to airlines by passenger. API covers  both inbound and outbound air passengers. API includes the passenger’s full name, nationality, date of birth, gender and travel document number, type and country of issue.The data does not include those arriving by sea or rail routes, by private aircraft or via the Common Travel Area (CTA).",
-  "type": "Data Service",
+  "type": ["Data Service"],
   "apiType": "REST",
   "serviceType": "Transactional",
   "theme": [

--- a/samples/data_share.json
+++ b/samples/data_share.json
@@ -5,7 +5,7 @@
   "status": "Published",
   "title": "Request to access Advance Passenger Information",
   "description": "DfE's travel team wish to access Travel data and personal data given to airlines by passenger.",
-  "type": "Data Share",
+  "type": ["Data Share"],
   "theme": [
     "Transport and infrastructure",
     "Population and society"

--- a/samples/dataset.json
+++ b/samples/dataset.json
@@ -5,7 +5,7 @@
   "status": "Published",
   "title": "Advance Passenger Information",
   "description": "Travel data and personal data given to airlines by passenger. API covers  both inbound and outbound air passengers. API includes the passenger’s full name, nationality, date of birth, gender and travel document number, type and country of issue.The data does not include those arriving by sea or rail routes, by private aircraft or via the Common Travel Area (CTA).",
-  "type": "Data Set",
+  "type": ["Data Set"],
   "theme": [
     "Transport and infrastructure",
     "Population and society"

--- a/schema/cataloged_resource_schema.json
+++ b/schema/cataloged_resource_schema.json
@@ -70,7 +70,7 @@
     },
     "license": {
       "description": "A legal document under which the resource is made available.",
-      "type": "Object",
+      "type": "object",
       "properties": {
         "title": {
           "description": "Name or title used to label license",
@@ -144,13 +144,16 @@
     },
     "type": {
       "description": "Topic: A controlled term that expresses the broad topical content of an information resource. Subject: A controlled term that expresses a topic of the intellectual content of an information resource.",
-      "type": "string",
-      "enum": [
-        "Data Set",
-        "Data Service",
-        "Data Group",
-        "Data Share"
-      ]
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Data Set",
+          "Data Service",
+          "Data Group",
+          "Data Share"
+        ]
+      }
     }
   },
   "required": [


### PR DESCRIPTION
Also fix typo in license definition

To be merged if required.

This fix is needed because of an issue with the Data Marketplace search tool not being able to determine type of distributions.